### PR TITLE
Remaining cukes

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -68,7 +68,7 @@ class GroupsController < ApplicationController
 
   # GET /groups/1/edit
   def edit
-    @group = Group.includes(:users, :memberships).find(params[:id])
+    @group = Group.eager_load(:members, :users).find(params[:id])
   end
 
   # POST /groups

--- a/features/step_definitions/timelines_given_steps.rb
+++ b/features/step_definitions/timelines_given_steps.rb
@@ -137,10 +137,16 @@ def create_work_packages_from_table(table, project)
       end
     end
 
+    # Force project to have a type the WP can use
+    if project.types.empty?
+      project.types << FactoryGirl.create(:type_standard)
+      project.save!
+    end
+
     # lookup the type by its name and replace it with the type
     # if the cast is ommitted, the contents of type_attributes is interpreted as an int
-    unless type_attributes.has_key? :type
-      type_attributes[:type] = ::Type.where(name: type_attributes[:type].to_s).first
+    if type_attributes.has_key? :type
+      ::Type.find_by(name: type_attributes[:type])
     end
 
     if type_attributes.has_key? 'author'


### PR DESCRIPTION
Hi Alex,

this should fix all but one cuke (to which I comment on the OP PR)

Best,
Oliver
## 

When the project has no types available, and work package is created
through the factory, it will raise an inclusion error from
`work_package/validations`.

This change forces projects to have a default type in the case
they do not (yet).

This also fixes a wrong assignment of type from name, which however
doesn't seem to be used (yet).
