### PR TITLE
Fix missing assign

### DIFF
--- a/features/step_definitions/timelines_given_steps.rb
+++ b/features/step_definitions/timelines_given_steps.rb
@@ -146,7 +146,7 @@ def create_work_packages_from_table(table, project)
     # lookup the type by its name and replace it with the type
     # if the cast is ommitted, the contents of type_attributes is interpreted as an int
     if type_attributes.has_key? :type
-      ::Type.find_by(name: type_attributes[:type])
+      type_attributes[:type] = ::Type.find_by(name: type_attributes[:type])
     end
 
     if type_attributes.has_key? 'author'


### PR DESCRIPTION
Hi @myabc , while reviewing and testing your changes I've found an error I've included in the spec fixes.
In `features/step_definitions/timelines_given_steps.rb`, when a `:type` name is given , it should be replaced with the actual type object. It isn't.

However, this key doesn't seem to be used, thus there was no failure.
