### PR TITLE
Try to aid in rails 4.2 spec fixes

### DIFF
--- a/lib/open_project/notifications.rb
+++ b/lib/open_project/notifications.rb
@@ -47,7 +47,7 @@ module OpenProject
     # delivered (although it is not at the moment), so don't count on object equality
     # for the payload.
     def self.send(name, payload)
-      ActiveSupport::Notifications.instrument(name, payload)
+      ActiveSupport::Notifications.instrument(name.to_s, payload)
     end
   end
 end


### PR DESCRIPTION
- ~~Use string callback name in OpenProject::Notifications~~

Going to push more here when I find it.
