### PR TITLE
fix project permission condition in activity

### DIFF
--- a/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
+++ b/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
@@ -194,7 +194,7 @@ module Redmine
                 allowed_projects << projects.map(&:id) if perm && role.allowed_to?(perm.name)
               end
 
-              stmt = projects_table[:id].in(allowed_projects.uniq)
+              stmt = projects_table[:id].in(allowed_projects.flatten.uniq)
             end
 
             if perm && (Role.anonymous.allowed_to?(perm.name) || Role.non_member.allowed_to?(perm.name)) && !is_member

--- a/spec/legacy/unit/activity_spec.rb
+++ b/spec/legacy/unit/activity_spec.rb
@@ -82,7 +82,6 @@ describe Activity, type: :model do
 
     assert events.include?(WorkPackage.find(1))
     # Issue of a private project the user belongs to
-    pending 'check permissions'
     assert events.include?(WorkPackage.find(6))
   end
 


### PR DESCRIPTION
Without the #flatten, the arel visitor casts the two arrays to NULL.
